### PR TITLE
IOS-2431 Reduces onDown calls in ListItemTalkButton

### DIFF
--- a/ZelloSDKExampleApp/Shared/ListItemTalkButton.swift
+++ b/ZelloSDKExampleApp/Shared/ListItemTalkButton.swift
@@ -24,8 +24,10 @@ struct ListItemTalkButton: View {
     .simultaneousGesture(
       DragGesture(minimumDistance: 0)
         .onChanged { _ in
-          isPressed = true
-          onDown()
+          if !isPressed {
+            isPressed = true
+            onDown()
+          }
         }
         .onEnded { _ in
           isPressed = false


### PR DESCRIPTION
The code was calling onDown repeatedly when it should only be calling it when the button is first pressed.